### PR TITLE
Add a help command

### DIFF
--- a/src/help/np-add.txt
+++ b/src/help/np-add.txt
@@ -1,0 +1,41 @@
+Usage: np add [LIMIT] [ORDER] [PATH...]
+
+Add some sounds to the queue.
+
+Arguments:
+  LIMIT
+    Values:  number or "all"
+    Default: 3
+
+  ORDER
+    Values:  "in-order" or "shuffle"
+    Default: "shuffle"
+
+  PATH
+    Values:  Path to sound file, folders or "-" for piped values
+    Default: "$PWD"
+
+Examples:
+  # Add the default number of shuffled sounds from the current folder.
+  np add
+
+  # Add a single sound to the queue.
+  np add path/to/sound.mp3
+
+  # Add 25 shuffled sounds from the current folder.
+  np add 25
+
+  # Add the first 2 sounds from the current folder.
+  np add 2 in-order
+
+  # Add shuffled sounds from a folder, hierarchically.
+  np add path/to/folder/with/sounds/
+
+  # Add an album.
+  np add all in-order "Jazz/My Favorite Album/"
+
+  # Add sounds by null-delimited paths from stdin.
+  find . -iname '*best of*.mp3' -print0 | np add -
+
+  # Add 10 shuffled sounds from the combined list of a single sound, stdin and a folder.
+  find . -iname '*best of*.mp3' -print0 | np add 10 path/to/sound.mp3 - path/to/folder/with/sounds/

--- a/src/help/np-clean.txt
+++ b/src/help/np-clean.txt
@@ -1,0 +1,3 @@
+Usage: np clear
+
+Empty the queue.

--- a/src/help/np-clear.txt
+++ b/src/help/np-clear.txt
@@ -1,0 +1,3 @@
+Usage: np clean
+
+Remove non-existant files from queue.

--- a/src/help/np-daemon.txt
+++ b/src/help/np-daemon.txt
@@ -1,0 +1,19 @@
+Usage: np daemon [options...]
+
+Play sounds in queue as soon as there are any.
+Can be controlled with 'np start' and 'np stop',
+as well as the rest of the queue commands.
+
+Options:
+  --is-running      Check if the daemon process has already started.
+                    Exits with '0' if it has, '1' otherwise.
+
+  --stop            Stop daemon execution. Can be used during system
+                    shutdown, but isn't part of everyday usage.
+
+  --verbose         Output paths to the sounds as they play.
+
+Examples:
+  # Start the daemon, let it run in the background.
+  # Should be done at user login.
+  np daemon --is-running || ( np daemon & )

--- a/src/help/np-doctor.txt
+++ b/src/help/np-doctor.txt
@@ -1,0 +1,3 @@
+Usage: np doctor
+
+Display configuration, runtime and status values.

--- a/src/help/np-help.txt
+++ b/src/help/np-help.txt
@@ -1,0 +1,60 @@
+npshell np -- command line music queue manager
+
+Usage: np <command> [arguments...]
+       np help <command>
+
+Commands:
+
+  Queue Commands:
+    now         Shows the sound currently playing
+    list        See sounds currently in the queue
+    add         Add some sounds to the queue
+    clear       Empty the queue
+    clean       Remove non-existant files from queue
+
+  Playback Commands:
+    next        Play next sound in the queue
+    start       Start playback
+    stop        Stop playback
+    startstop   Toggle playback
+
+  Other Commands:
+    daemon      Control the playback daemon
+    notify      Control the notification daemon
+    history     Show the 999 most recently played sounds
+    index       Save the list of sounds in the current folder (recursive)
+    doctor      Display configuration, runtime and status values
+    help        Display usage help
+
+Configuration:
+
+  Settings are read from '~/.np/config.sh'.
+  The format is one 'setting=value' per line.
+
+  Settings:
+    configNumsounds
+      Number of sounds 'np add' adds
+
+      Values:  number ("all" not allowed)
+      Default: 3
+
+    configOrder
+      Order of files 'np add' adds
+
+      Values:  "in-order" or "shuffle"
+      Default: "shuffle"
+
+    configDebug
+      Enable debug output
+
+      Values:  "true" or "false"
+      Default: "false"
+
+    configUseCache
+      Automatically generate index files
+      for each loaded folder. See also 'np index'
+
+      Values:  "true" or "false"
+      Default: "true"
+
+See 'np help <command>' for more information on a specific command.

--- a/src/help/np-history.txt
+++ b/src/help/np-history.txt
@@ -1,0 +1,3 @@
+Usage: np history
+
+Show the 999 most recently played sounds.

--- a/src/help/np-index.txt
+++ b/src/help/np-index.txt
@@ -1,0 +1,12 @@
+Usage: np index [options...]
+
+Create a file with a cached list of
+all sounds in the current folder.
+
+Options:
+  --force           Recreate the index file even
+                    if it already exists.
+
+  --clean           Remove index files.
+
+  --recursive       Perform the action in subfolders.

--- a/src/help/np-list.txt
+++ b/src/help/np-list.txt
@@ -1,0 +1,3 @@
+Usage: np list
+
+See sounds currently in the queue.

--- a/src/help/np-next.txt
+++ b/src/help/np-next.txt
@@ -1,0 +1,3 @@
+Usage: np list
+
+Advance to the next sound in the queue.

--- a/src/help/np-notify.txt
+++ b/src/help/np-notify.txt
@@ -1,0 +1,17 @@
+Usage: np notify [options...]
+
+Show notifications when the track changes,
+playback is started/stopped or the queue is empty.
+
+Options:
+  --is-running      Check if the daemon process has already started.
+                    Exits with '0' if it has, '1' otherwise.
+
+  --stop            Stop notification daemon execution.
+                    Can be used during system shutdown,
+                    but isn't part of everyday usage.
+
+Examples:
+  # Start the notification daemon, let it run in the background.
+  # Should be done at user login.
+  np notify --is-running || ( np notify & )

--- a/src/help/np-now.txt
+++ b/src/help/np-now.txt
@@ -1,0 +1,4 @@
+Usage: np now
+
+  Shows the sound currently playing.
+

--- a/src/help/np-start.txt
+++ b/src/help/np-start.txt
@@ -1,0 +1,3 @@
+Usage: np start
+
+Let 'np daemon' consume the sound queue.

--- a/src/help/np-startstop.txt
+++ b/src/help/np-startstop.txt
@@ -1,0 +1,3 @@
+Usage: np startstop
+
+Toggle playback between 'np start' and 'np stop'.

--- a/src/help/np-stop.txt
+++ b/src/help/np-stop.txt
@@ -1,0 +1,3 @@
+Usage: np stop
+
+Don't let 'np daemon' consume the sound queue.

--- a/src/np-help.sh
+++ b/src/np-help.sh
@@ -1,0 +1,19 @@
+#!/usr/bin/env bash
+set -e
+
+action=""
+
+(( "$#" > 0 )) && { action="$1"; shift; }
+
+[[ -z "$action" ]] && action="help"
+
+helpfile="${BASH_SOURCE%/*}/help/np-${action}.txt"
+
+if [[ -f $helpfile ]];
+then
+	cat $helpfile
+else
+	echo -E "np: '${action}' is not a action." 1>&2
+	exit 1
+fi
+


### PR DESCRIPTION
Add a help command along with help files. Usage:

``` bash
$ np help
$ np help add
$ np help help
```
